### PR TITLE
change min R ver to 4.2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,7 +33,7 @@ Imports:
 Suggests:
     testthat (>= 3.0.0)
 Depends:
-  R (>= 4.1)
+  R (>= 4.2)
 VignetteBuilder: knitr
 Config/testthat/edition: 3
 URL: https://github.com/Boehringer-Ingelheim/BayesianMCPMod


### PR DESCRIPTION
The reason is that the code here in plot.R depends on 4.2 using the new pipe operator.
```
      paste_names <- names(mod_weights) |>
        gsub("exponential", "exp", x = _) |>
        gsub("quadratic",  "quad", x = _) |>
        gsub("linear",      "lin", x = _) |>
        gsub("logistic",    "log", x = _) |>
        gsub("sigEmax",    "sigE", x = _)
```